### PR TITLE
Fix error when no diff is present. Fixes #2

### DIFF
--- a/src/Services/EventLoggerService.php
+++ b/src/Services/EventLoggerService.php
@@ -79,7 +79,9 @@ class EventLoggerService
             $history                    = json_decode($actionHistoryItem, true);
             $history['timeago']         = $this->timeAgo->inWords($history['time']);
             $history['hydratedMessage'] = $this->translate($history['message'], $history['data']);
-            $history['diff']            = $this->differ->diff($history['data'][':before'], $history['data'][':after']);
+            if(isset($history['data'][':before']) && isset($history['data'][':after'])){
+                $history['diff']        = $this->differ->diff($history['data'][':before'], $history['data'][':after']);
+            }
             $actionHistory[]            = $history;
         }
         return $actionHistory;


### PR DESCRIPTION
The before and after of a logged event are not always relevant.

For example we don't want a before and after on logging a password change. Currently trying to retrieve a logged event without before and after causes an exception